### PR TITLE
chore: .nvmrc

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts-hydrogen


### PR DESCRIPTION
### Description

- node version set to `lts-hydrogen` via `.nvmrc` works with `fnm` not sure about `nvm`

### How To Test

- with fnm installed, cd into project and test to see if your local version was updated to lts-hydrogen
  - you might need to run `fnm use`
- running 'node --version' should read version whatever lts-hydrogen is at [releases](https://nodejs.org/en/download/releases/)

### Pics / Vids

n/a

### Libraries Added

n/a
